### PR TITLE
Include algorithm header explicitly

### DIFF
--- a/src/fastwer.cpp
+++ b/src/fastwer.cpp
@@ -1,5 +1,7 @@
 #include "fastwer.hpp"
 
+#include <algorithm>
+
 
 namespace {
 


### PR DESCRIPTION
## Summary
- include the standard algorithm header directly where std::min and std::swap are used
- avoid relying on transitive standard-library includes, improving compiler portability

Closes #4

## Testing
- python -m pip install .
- python -m unittest -v tests.basic