### PR TITLE
Write test temp files as UTF-8

### DIFF
--- a/tests/basic.py
+++ b/tests/basic.py
@@ -35,7 +35,8 @@ class TruncatedDataFilePath(object):
                 return f'{sent}{self.SPACE}{utterance_id}\n'
             data = [process_line(s) for s in data]
 
-        with tempfile.NamedTemporaryFile(mode='w', delete=False) as f:
+        with tempfile.NamedTemporaryFile(
+                mode='w', encoding='utf-8', delete=False) as f:
             for r in data:
                 f.write(r)
             self.path = f.name


### PR DESCRIPTION
## Summary
- write generated test fixtures with an explicit UTF-8 encoding
- avoid Windows CP1252 failures for the U+2581 character marker

## Testing
- /tmp/fastwer-ci-venv-20260902/bin/python -m unittest -v tests.basic